### PR TITLE
Temporarly reduce max width

### DIFF
--- a/public_html/config.php
+++ b/public_html/config.php
@@ -1,6 +1,6 @@
 <?php
 // all images above this size are tiled (and temporarily shown as a max_size rescaled version)
-$max_width = 4000;
+$max_width = 3700; // Temporarly reduced from 4000 to address issues in Thumbor T344233
 
 // send content type header and prevent caching
 header('Content-Type: application/json');


### PR DESCRIPTION
Some users reported problems with Panoviewer and these turned out to be actually related to the Mediawiki thumbnail generation with certain input and requested output.

https://phabricator.wikimedia.org/T342425

I'm not sure how quickly the issues can be addressed in core and if it's related to the underlying libraries used that are tight to the Debian version of the Thumbor service. From experiments with Thumbor it seems, that reducing the requested size a bit brings more stability to the Thumbnail generation from big panorama pictures.

This change could probably be reverted again when the underlying issue is fixed.

https://phabricator.wikimedia.org/T344233